### PR TITLE
Ensure the request is always logged

### DIFF
--- a/requestlogger.go
+++ b/requestlogger.go
@@ -54,12 +54,13 @@ func (rl *RequestLogger) Handle(next http.Handler) http.Handler {
 
 		start := time.Now().UTC()
 		next.ServeHTTP(w, r)
-		end := time.Now().UTC()
 
-		log.latency = end.Sub(start) / 1000000
-		log.contextError = r.Context().Err()
-
-		log.log()
+		defer func() {
+			end := time.Now().UTC()
+			log.latency = end.Sub(start) / 1000000
+			log.contextError = r.Context().Err()
+			log.log()
+		}()
 	})
 }
 


### PR DESCRIPTION
The request logging code after serving the HTTP request is now wrapped
in a `defer` call to make sure it is logged even if something happens to
the server during the request.