### PR TITLE
Fix basic output formatting bug

### DIFF
--- a/logger.go
+++ b/logger.go
@@ -44,7 +44,7 @@ type Logger interface {
 	Fatald(string, interface{})
 
 	// Create a logger object with additional tags
-	Sublogger(tags...string) Logger
+	Sublogger(tags ...string) Logger
 
 	// Private methods
 	newLogMessage(message string, level Level, skipOffset int, data interface{}) *logMessage
@@ -103,7 +103,7 @@ func (l *logger) printMessage(output string, level Level, d interface{}) {
 		return
 	}
 
-	fmt.Printf(l.newLogMessage(output, level, 0, d).String() + "\n")
+	fmt.Println(l.newLogMessage(output, level, 0, d).String())
 }
 
 func (l *logger) exit() {

--- a/sublogger.go
+++ b/sublogger.go
@@ -9,7 +9,7 @@ import (
 // sublogger allows for logging with additional tags
 type sublogger struct {
 	Logger
-	subTags []string
+	subTags    []string
 	skipOffset int
 }
 
@@ -18,8 +18,8 @@ type sublogger struct {
 // Sublogger returns a new sublogger with the provided tags
 func Sublogger(tags ...string) Logger {
 	return &sublogger{
-		Logger:  LoggerSingleton,
-		subTags: tags,
+		Logger:     LoggerSingleton,
+		subTags:    tags,
 		skipOffset: 0,
 	}
 }
@@ -27,8 +27,8 @@ func Sublogger(tags ...string) Logger {
 // Sublogger returns a new sublogger with the provided tags
 func (sl *sublogger) Sublogger(tags ...string) Logger {
 	return &sublogger{
-		Logger:  sl,
-		subTags: tags,
+		Logger:     sl,
+		subTags:    tags,
 		skipOffset: 1,
 	}
 }
@@ -163,7 +163,7 @@ func (sl *sublogger) Fatald(message string, d interface{}) {
 
 // newLogMessage creates a new *logMessage
 func (sl *sublogger) newLogMessage(output string, level Level, skipOffset int, d interface{}) *logMessage {
-	m := sl.Logger.newLogMessage(output, level, sl.skipOffset + skipOffset, d)
+	m := sl.Logger.newLogMessage(output, level, sl.skipOffset+skipOffset, d)
 	m.Tags = append(m.Tags, sl.subTags...)
 	return m
 }
@@ -174,5 +174,5 @@ func (sl *sublogger) printMessage(output string, level Level, d interface{}) {
 		return
 	}
 
-	fmt.Printf(sl.newLogMessage(output, level, 0, d).String() + "\n")
+	fmt.Println(sl.newLogMessage(output, level, 0, d).String())
 }


### PR DESCRIPTION
The print statement used `fmt.Printf` unnecessarily, causing built log string to be processed as a format string, and anything in the string resembling a placeholder would be replaced with a `(MISSING)`. This became apparent in the request logger with URL-encoded text. Replacing `Printf` with `Println` solves this problem.