### PR TITLE
Add logging for GraphQL requests

### DIFF
--- a/requestlogger.go
+++ b/requestlogger.go
@@ -285,16 +285,17 @@ func makeLog(r *http.Request, opts RequestLoggerConfig) (requestLog, error, int)
 
 // label returns the message to print to the log
 func (rl requestLog) label() string {
+	latencyMs := rl.latency * time.Nanosecond / time.Millisecond
 	var label string
 	switch {
 	case errors.Is(rl.contextError, context.DeadlineExceeded):
-		label = fmt.Sprintf("%s %s: %dms (DEADLINE EXCEEDED)", rl.method, rl.path, rl.latency)
+		label = fmt.Sprintf("%s %s: %dms (DEADLINE EXCEEDED)", rl.method, rl.path, latencyMs)
 	case errors.Is(rl.contextError, context.Canceled):
-		label = fmt.Sprintf("%s %s: %dms (CANCELLED)", rl.method, rl.path, rl.latency)
+		label = fmt.Sprintf("%s %s: %dms (CANCELLED)", rl.method, rl.path, latencyMs)
 	case rl.contextError != nil:
-		label = fmt.Sprintf("%s %s: %dms (%s)", rl.method, rl.path, rl.latency, rl.contextError)
+		label = fmt.Sprintf("%s %s: %dms (%s)", rl.method, rl.path, latencyMs, rl.contextError)
 	default:
-		label = fmt.Sprintf("%s %s: %dms", rl.method, rl.path, rl.latency)
+		label = fmt.Sprintf("%s %s: %dms", rl.method, rl.path, latencyMs)
 	}
 	return label
 }

--- a/requestlogger.go
+++ b/requestlogger.go
@@ -22,6 +22,7 @@ type RequestLogger struct {
 	logHeaders            bool
 	logParams             bool
 	logBody               bool
+	logGraphql            bool
 	normalLevel           Level
 	deadlineExceededLevel Level
 	contextCancelledLevel Level
@@ -74,6 +75,7 @@ func (rl *RequestLogger) Handle(next http.Handler) http.Handler {
 		Headers: rl.logHeaders,
 		Params:  rl.logParams,
 		Body:    rl.logBody,
+		GraphQL: rl.logGraphql,
 	}
 	logChan := make(chan requestLog)
 
@@ -102,7 +104,7 @@ func (rl *RequestLogger) Handle(next http.Handler) http.Handler {
 
 // String returns the requestLog as a formatted string
 func (rl requestLog) String() string {
-	var headerStr, paramStr, bodyStr string
+	var headerStr, paramStr, bodyStr, graphqlStr string
 
 	// format headers
 	if i, l := 0, len(rl.headers); l > 0 {
@@ -129,7 +131,11 @@ func (rl requestLog) String() string {
 		bodyStr = "\nBody: " + rl.body
 	}
 
-	return headerStr + paramStr + bodyStr
+	if rl.graphql != "" {
+		graphqlStr = rl.graphql
+	}
+
+	return graphqlStr + headerStr + paramStr + bodyStr
 }
 
 // MarshalJSON returns the requestLog as a JSON object
@@ -183,6 +189,7 @@ func NewRequestLogger(config RequestLoggerConfig) *RequestLogger {
 		client:                config.Client,
 		logHeaders:            config.Headers,
 		logParams:             config.Params,
+		logGraphql:            config.GraphQL,
 		logBody:               config.Body,
 		normalLevel:           normal,
 		deadlineExceededLevel: deadline,


### PR DESCRIPTION
This modifies logs that use to say:
```
POST /graphql: 653ms
POST /graphql: 59ms
```
Into something like
```
POST /graphql: 653ms q SmartPass
POST /graphql: 59ms m CreateListing
```