### PR TITLE
Attach graphql metadata to json logs if set

### DIFF
--- a/requestlogger.go
+++ b/requestlogger.go
@@ -157,6 +157,9 @@ func (rl requestLog) MarshalJSON() ([]byte, error) {
 	if len(rl.body) > 0 {
 		obj["body"] = rl.body
 	}
+	if len(rl.graphql) > 0 {
+		obj["graphql"] = rl.graphql
+	}
 
 	return json.Marshal(obj)
 }


### PR DESCRIPTION
## Add GraphQL Field to Request Logger JSON Output
Added GraphQL field serialization to the requestLog MarshalJSON method to include GraphQL data in JSON output when present

### 📍Where to Start
The `MarshalJSON` method in [requestlogger.go](https://github.com/parkhub/go-parkhub-logger/pull/24/files#diff-0c6788a16fb36acdbeda48fcc13b158bd623eb0613fe15cbbd47a2b73ebc8e44)

----

_[Macroscope](https://app.macroscope.com) summarized 0e86d5b and had no feedback after reviewing 1 code object._